### PR TITLE
fix: rename Recipe.Ingredients to snake_case and clean up code quality

### DIFF
--- a/app/core/migrations/0005_rename_ingredients_field.py
+++ b/app/core/migrations/0005_rename_ingredients_field.py
@@ -1,0 +1,23 @@
+"""
+Migration to rename Recipe.Ingredients → Recipe.ingredients.
+
+Rationale: Django field names must use snake_case. The original field
+was named 'Ingredients' (PascalCase) which is a Django anti-pattern
+and caused issues at the serializer layer.
+"""
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0004_auto_20260209_2116'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='recipe',
+            old_name='Ingredients',
+            new_name='ingredients',
+        ),
+    ]

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -89,7 +89,7 @@ class Recipe(models.Model):
     price = models.DecimalField(max_digits=5, decimal_places=2)
     link = models.CharField(max_length=255, blank=True)
     tags = models.ManyToManyField('Tag')
-    Ingredients = models.ManyToManyField('Ingredient')
+    ingredients = models.ManyToManyField('Ingredient')
 
     def __str__(self):
         return self.title

--- a/app/recipe/serializers.py
+++ b/app/recipe/serializers.py
@@ -12,7 +12,7 @@ from core.models import Recipe, Tag, Ingredient
 
 
 class IngredientSerializer(serializers.ModelSerializer):
-    """Serializer for ingredienst"""
+    """Serializer for ingredients."""
 
     class Meta:
         model = Ingredient
@@ -79,11 +79,11 @@ class RecipeSerializer(serializers.ModelSerializer):
         """Handle getting or creating ingredients as needed."""
         auth_user = self.context['request'].user
         for ingredient in ingredients:
-            ingredient_obj, create = Ingredient.objects.get_or_create(
+            ingredient_obj, created = Ingredient.objects.get_or_create(
                 user=auth_user,
                 **ingredient,
             )
-            recipe.Ingredients.add(ingredient_obj)
+            recipe.ingredients.add(ingredient_obj)
 
 
     def create(self, validated_data):
@@ -118,7 +118,7 @@ class RecipeSerializer(serializers.ModelSerializer):
             self._get_or_create_tags(tags, instance)
 
         if ingredients is not None:
-            instance.Ingredients.clear()
+            instance.ingredients.clear()
             self._get_or_create_ingredients(ingredients, instance)
 
         for attr, value in validate_data.items():

--- a/app/recipe/views.py
+++ b/app/recipe/views.py
@@ -33,7 +33,7 @@ class RecipeViewSet(viewsets.ModelViewSet):
 
 
     def perform_create(self, serializer):
-        """create a new recupe."""
+        """Create a new recipe."""
         serializer.save(user=self.request.user)
 
 class BaseRecipeAttrViewSet(mixins.DestroyModelMixin,
@@ -51,7 +51,7 @@ class BaseRecipeAttrViewSet(mixins.DestroyModelMixin,
 
 
 class TagViewSet(BaseRecipeAttrViewSet):
-    """Mange tags in the database"""
+    """Manage tags in the database."""
     serializer_class = serializers.TagSerializer
     queryset = Tag.objects.all()
 

--- a/app/user/views.py
+++ b/app/user/views.py
@@ -6,11 +6,8 @@ from rest_framework.settings import api_settings
 
 from user.serializers import (
     UserSerializer,
-    AuthTokenSerializer
-
+    AuthTokenSerializer,
 )
-
-from user.serializers import UserSerializer
 
 class CreateUserView(generics.CreateAPIView):
     """Create a new user in the system"""


### PR DESCRIPTION
## Summary
- Renames `Recipe.Ingredients` (PascalCase) → `Recipe.ingredients` (snake_case) to follow Django field naming conventions
- Adds Django migration `0005_rename_ingredients_field.py` to apply the rename without data loss
- Removes duplicate `UserSerializer` import in `user/views.py`
- Fixes typos in docstrings across `recipe/views.py` and `recipe/serializers.py`

## Changes
| File | Change |
|------|--------|
| `core/models.py` | `Ingredients` → `ingredients` field rename |
| `core/migrations/0005_*` | New migration for field rename |
| `recipe/serializers.py` | Use `recipe.ingredients` instead of `recipe.Ingredients`; fix typos |
| `recipe/views.py` | Fix typos in docstrings |
| `user/views.py` | Remove duplicate import |

## Test plan
- [ ] Run `docker compose run --rm app python manage.py migrate` — should apply migration cleanly
- [ ] Run `docker compose run --rm app python manage.py test` — all tests pass
- [ ] Verify ingredient add/remove on recipe endpoints still works

Closes #2