### PR TITLE
feat: JWT authentication with refresh tokens, rotation, and logout

### DIFF
--- a/app/user/serializers.py
+++ b/app/user/serializers.py
@@ -1,45 +1,32 @@
-from django.contrib.auth import (
-    get_user_model,
-    authenticate,
-)
-from django.utils.translation import  gettext as _
+"""Serializers for the user API."""
+from django.contrib.auth import get_user_model, authenticate
+from django.utils.translation import gettext as _
 
 from rest_framework import serializers
-
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 
 class UserSerializer(serializers.ModelSerializer):
-    """Serializer for the user object"""
+    """Serializer for the user object."""
 
     class Meta:
         model = get_user_model()
         fields = ('email', 'password', 'name')
         extra_kwargs = {
-            # Password can be sent IN, but never sent OUT
             'password': {
                 'write_only': True,
-                'min_length': 5
+                'min_length': 5,
             }
         }
 
     def create(self, validated_data):
-        """
-        Create and return a user with encrypted password.
-
-        Express equivalent:
-        User.create({
-          email,
-          password: hash(password),
-          name
-        })
-        """
+        """Create and return a user with an encrypted password."""
         return get_user_model().objects.create_user(**validated_data)
 
     def update(self, instance, validated_data):
-        """Update and return user"""
+        """Update and return user, re-hashing password if provided."""
         password = validated_data.pop('password', None)
         user = super().update(instance, validated_data)
-
         if password:
             user.set_password(password)
             user.save()
@@ -47,16 +34,14 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class AuthTokenSerializer(serializers.Serializer):
-    """Serializer for the user auth token"""
+    """Serializer for the legacy DRF auth token (email + password)."""
     email = serializers.EmailField()
     password = serializers.CharField(
         style={'input_type': 'password'},
         trim_whitespace=False,
-
     )
 
     def validate(self, attrs):
-        """Validate and authentication"""
         email = attrs.get('email')
         password = attrs.get('password')
         user = authenticate(
@@ -65,8 +50,27 @@ class AuthTokenSerializer(serializers.Serializer):
             password=password,
         )
         if not user:
-            msg = _('Unable to authenticate with provided credentials')
-            raise serializers.ValidationError(msg, code='authorization')
-
+            raise serializers.ValidationError(
+                _('Unable to authenticate with provided credentials.'),
+                code='authorization',
+            )
         attrs['user'] = user
         return attrs
+
+
+class EmailTokenObtainPairSerializer(TokenObtainPairSerializer):
+    """
+    JWT token pair serializer that accepts 'email' instead of 'username'.
+
+    simplejwt defaults to the USERNAME_FIELD on the user model, which we've
+    set to 'email', so this works automatically — we just add extra claims.
+    """
+
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+        # Embed non-sensitive user info directly in the token payload
+        # so the frontend does not need an extra /me/ call on login.
+        token['name'] = user.name
+        token['email'] = user.email
+        return token

--- a/app/user/tests/test_user_api.py
+++ b/app/user/tests/test_user_api.py
@@ -1,171 +1,115 @@
-"""
-Tests for the user API
-"""
-
-# Base class for Django tests.
-# Django creates a temporary test database automatically.
+"""Tests for the user API."""
 from django.test import TestCase
-
-# Returns the active User model (default or custom).
-# Always use this instead of importing User directly.
 from django.contrib.auth import get_user_model
-
-# Converts a URL name into the actual URL path.
-# Example: 'user:create' -> '/api/user/create/'
 from django.urls import reverse
 
-# REST framework client for making HTTP requests in tests.
 from rest_framework.test import APIClient
-
-# HTTP status codes (200, 201, 400, etc.)
 from rest_framework import status
 
 
-# URL for creating a user (resolved by name from urls.py)
 CREATE_USER_URL = reverse('user:create')
-TOKEN_URL = reverse('user:token')
-ME_URL = reverse('user:me')
+TOKEN_URL       = reverse('user:token')
+ME_URL          = reverse('user:me')
+JWT_LOGIN_URL   = reverse('user:jwt-login')
+JWT_REFRESH_URL = reverse('user:jwt-refresh')
+LOGOUT_URL      = reverse('user:logout')
 
 
 def create_user(**params):
-    """
-    Helper function to create and return a new user.
-    Used only inside tests to prepare test data.
-    """
     return get_user_model().objects.create_user(**params)
 
 
+# ── Public endpoints ──────────────────────────────────────────────────────────
+
 class PublicUserApiTests(TestCase):
-    """
-    Tests for public (unauthenticated) user API endpoints.
-    """
+    """Tests for unauthenticated user API endpoints."""
 
     def setUp(self):
-        """
-        Runs before each test.
-        Creates a new API client instance.
-        """
         self.client = APIClient()
 
-    def test_create_user_success(self):
-        """
-        Test that creating a user with valid data succeeds.
-        """
-        payload = {
-            'email': 'test@example.com',
-            'password': 'testpass123',
-            'name': 'Test Name'
-        }
+    # -- User creation --------------------------------------------------------
 
-        # Send POST request to create user endpoint
+    def test_create_user_success(self):
+        payload = {'email': 'test@example.com', 'password': 'testpass123', 'name': 'Test Name'}
         res = self.client.post(CREATE_USER_URL, payload)
 
-        # Check that the response status is 201 CREATED
         self.assertEqual(res.status_code, status.HTTP_201_CREATED)
-
-        # Retrieve the user from the database
         user = get_user_model().objects.get(email=payload['email'])
-
-        # Verify the password was hashed correctly
         self.assertTrue(user.check_password(payload['password']))
-
-        # Ensure password is NOT returned in the API response
         self.assertNotIn('password', res.data)
 
     def test_user_with_email_exists_error(self):
-        """
-        Test that creating a user with an existing email fails.
-        """
-        payload = {
-            'email': 'test@example.com',
-            'password': 'testpass123',
-            'name': 'Test Name'
-        }
-
-        # Create a user with the same email first
+        payload = {'email': 'test@example.com', 'password': 'testpass123', 'name': 'Test Name'}
         create_user(**payload)
-
-        # Try to create another user with the same email
         res = self.client.post(CREATE_USER_URL, payload)
-
-        # Expect a 400 BAD REQUEST error
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_password_too_short_error(self):
-        """
-        Test that a password shorter than 5 characters is rejected.
-        """
-        payload = {
-            'email': 'test@example.com',
-            'password': 'pw',  # too short
-            'name': 'Test name',
-        }
-
-        # Send POST request with invalid password
+        payload = {'email': 'test@example.com', 'password': 'pw', 'name': 'Test name'}
         res = self.client.post(CREATE_USER_URL, payload)
-
-        # Expect validation error
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(get_user_model().objects.filter(email=payload['email']).exists())
 
-        # Check that the user was NOT created in the database
-        user_exists = get_user_model().objects.filter(
-            email=payload['email']
-        ).exists()
-
-        self.assertFalse(user_exists)
+    # -- Legacy DRF token -----------------------------------------------------
 
     def test_create_token_for_user(self):
-        '""Test generatoes token for valid credentials'
-
-        user_details = {
-            'name': 'Test Name',
-            'email': 'test@example.com',
-            'password': 'test-user-password0123',
-        }
+        user_details = {'name': 'Test Name', 'email': 'test@example.com', 'password': 'test-user-password0123'}
         create_user(**user_details)
-
-        payload = {
-            'email': user_details['email'],
-            'password': user_details['password'],
-
-        }
-        res = self.client.post(TOKEN_URL, payload)
-
+        res = self.client.post(TOKEN_URL, {'email': user_details['email'], 'password': user_details['password']})
         self.assertIn('token', res.data)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
 
-    def test_create_token_bad_credentianls(self):
-        """Test return error if credentials invalid"""
-
+    def test_create_token_bad_credentials(self):
         create_user(email='test@example.com', password='goodpass')
-
-        payload = {'email': 'test@example.com', 'password': 'badpass'}
-        res = self.client.post(TOKEN_URL, payload)
-
+        res = self.client.post(TOKEN_URL, {'email': 'test@example.com', 'password': 'badpass'})
         self.assertNotIn('token', res.data)
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-
 
     def test_create_token_blank_password(self):
-        """Test posting a blank password"""
-        payload = {'email':'test@example.com', 'password': ''}
-        res = self.client.post(TOKEN_URL, payload)
-
+        res = self.client.post(TOKEN_URL, {'email': 'test@example.com', 'password': ''})
         self.assertNotIn('token', res.data)
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_retrieve_user_unauthorized(self):
-        """Test authorized is required for users."""
-        res = self.client.get(ME_URL)
+    # -- JWT ------------------------------------------------------------------
 
+    def test_jwt_login_returns_access_and_refresh(self):
+        """JWT login returns both access and refresh tokens."""
+        create_user(email='jwt@example.com', password='testpass123', name='JWT User')
+        res = self.client.post(JWT_LOGIN_URL, {'email': 'jwt@example.com', 'password': 'testpass123'})
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIn('access', res.data)
+        self.assertIn('refresh', res.data)
+
+    def test_jwt_login_bad_credentials(self):
+        """JWT login with wrong password returns 401."""
+        create_user(email='jwt@example.com', password='correct', name='JWT User')
+        res = self.client.post(JWT_LOGIN_URL, {'email': 'jwt@example.com', 'password': 'wrong'})
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_jwt_refresh_returns_new_access_token(self):
+        """Valid refresh token returns a new access token."""
+        create_user(email='jwt@example.com', password='testpass123', name='JWT User')
+        login_res = self.client.post(JWT_LOGIN_URL, {'email': 'jwt@example.com', 'password': 'testpass123'})
+        refresh_token = login_res.data['refresh']
+
+        res = self.client.post(JWT_REFRESH_URL, {'refresh': refresh_token})
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIn('access', res.data)
+
+    # -- Unauthenticated access -----------------------------------------------
+
+    def test_retrieve_user_unauthorized(self):
+        res = self.client.get(ME_URL)
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
+# ── Private endpoints ─────────────────────────────────────────────────────────
+
 class PrivateUserApiTests(TestCase):
-    """Test API requests that require authontication"""
+    """Tests for authenticated user API endpoints."""
 
     def setUp(self):
-        self.user = create_user (
+        self.user = create_user(
             email='test@example.com',
             password='testpass123',
             name='Test Name',
@@ -174,28 +118,44 @@ class PrivateUserApiTests(TestCase):
         self.client.force_authenticate(user=self.user)
 
     def test_retrieve_profile_success(self):
-        """Test retrieving profile for logged in user."""
         res = self.client.get(ME_URL)
-
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(res.data, {
-            'name': self.user.name,
-            'email': self.user.email,
-        })
+        self.assertEqual(res.data, {'name': self.user.name, 'email': self.user.email})
 
     def test_post_me_not_allowed(self):
-        """Test POST is not allowed for the me endpoint."""
         res = self.client.post(ME_URL, {})
-
         self.assertEqual(res.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_update_user_profile(self):
-        """Test updating the user profile for the authenticatied"""
-        payload = {'name': 'Updated name', 'password':'newpassword123'}
-
+        payload = {'name': 'Updated name', 'password': 'newpassword123'}
         res = self.client.patch(ME_URL, payload)
-
         self.user.refresh_from_db()
         self.assertEqual(self.user.name, payload['name'])
         self.assertTrue(self.user.check_password(payload['password']))
         self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_logout_blacklists_refresh_token(self):
+        """Logout endpoint blacklists the refresh token."""
+        # Get tokens for this user
+        self.client.force_authenticate(user=None)   # use real JWT for this test
+        login_res = self.client.post(
+            JWT_LOGIN_URL,
+            {'email': 'test@example.com', 'password': 'testpass123'},
+        )
+        self.assertEqual(login_res.status_code, status.HTTP_200_OK)
+        access  = login_res.data['access']
+        refresh = login_res.data['refresh']
+
+        # Logout
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {access}')
+        res = self.client.post(LOGOUT_URL, {'refresh': refresh})
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        # Attempt to use the blacklisted refresh token
+        res2 = self.client.post(JWT_REFRESH_URL, {'refresh': refresh})
+        self.assertEqual(res2.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_logout_missing_refresh_token_returns_400(self):
+        """Logout with no refresh token returns 400."""
+        res = self.client.post(LOGOUT_URL, {})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)

--- a/app/user/urls.py
+++ b/app/user/urls.py
@@ -1,5 +1,4 @@
-"""Url mappings for the user api"""
-
+"""URL mappings for the user API."""
 from django.urls import path
 
 from user import views
@@ -7,7 +6,16 @@ from user import views
 app_name = 'user'
 
 urlpatterns = [
+    # ── User management ───────────────────────────────────────────────────────
     path('create/', views.CreateUserView.as_view(), name='create'),
+    path('me/',     views.ManageUserView.as_view(), name='me'),
+    path('logout/', views.LogoutView.as_view(),     name='logout'),
+
+    # ── JWT auth (recommended) ────────────────────────────────────────────────
+    path('jwt/login/',   views.JWTLoginView.as_view(),   name='jwt-login'),
+    path('jwt/refresh/', views.JWTRefreshView.as_view(), name='jwt-refresh'),
+    path('jwt/verify/',  views.JWTVerifyView.as_view(),  name='jwt-verify'),
+
+    # ── Legacy DRF token auth (backwards-compat) ──────────────────────────────
     path('token/', views.CreateTokenView.as_view(), name='token'),
-    path('me/', views.ManageUserView.as_view(), name='me'),
 ]

--- a/app/user/views.py
+++ b/app/user/views.py
@@ -1,29 +1,124 @@
 """Views for the user API."""
-
-from rest_framework import generics, authentication, permissions
+from rest_framework import generics, authentication, permissions, status
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.response import Response
 from rest_framework.settings import api_settings
+from rest_framework.views import APIView
+from rest_framework.throttling import AnonRateThrottle
+
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from user.serializers import (
     UserSerializer,
     AuthTokenSerializer,
+    EmailTokenObtainPairSerializer,
 )
 
+
+class LoginRateThrottle(AnonRateThrottle):
+    """Stricter throttle applied only to the login endpoint (5/min)."""
+    scope = 'login'
+
+
 class CreateUserView(generics.CreateAPIView):
-    """Create a new user in the system"""
+    """Create a new user in the system."""
     serializer_class = UserSerializer
+    permission_classes = [permissions.AllowAny]
+
 
 class CreateTokenView(ObtainAuthToken):
-    """Create a new auth token for user."""
+    """
+    Obtain a legacy DRF token (kept for backwards compatibility).
+    Prefer the JWT endpoints below for new integrations.
+    """
     serializer_class = AuthTokenSerializer
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES
+    throttle_classes = [LoginRateThrottle]
+
 
 class ManageUserView(generics.RetrieveUpdateAPIView):
-    """Manage the authenticated user."""
+    """Retrieve or update the authenticated user's profile."""
     serializer_class = UserSerializer
-    authentication_classes = [authentication.TokenAuthentication]
+    authentication_classes = [
+        JWTAuthentication,
+        authentication.TokenAuthentication,
+    ]
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):
-        """Retrieve and return the authenticated user."""
         return self.request.user
+
+
+# ── JWT endpoints ─────────────────────────────────────────────────────────────
+
+class JWTLoginView(TokenObtainPairView):
+    """
+    Obtain a JWT access + refresh token pair.
+
+    POST /api/user/jwt/login/
+    Body: { "email": "...", "password": "..." }
+    Returns: { "access": "...", "refresh": "..." }
+
+    - access token valid for 15 minutes (contains name + email claims)
+    - refresh token valid for 7 days (rotated on each refresh)
+    """
+    serializer_class = EmailTokenObtainPairSerializer
+    throttle_classes = [LoginRateThrottle]
+
+
+class JWTRefreshView(TokenRefreshView):
+    """
+    Refresh the JWT access token using a valid refresh token.
+
+    POST /api/user/jwt/refresh/
+    Body: { "refresh": "..." }
+    Returns: { "access": "...", "refresh": "..." }  (refresh rotated)
+    """
+
+
+class JWTVerifyView(TokenVerifyView):
+    """
+    Verify that a JWT access token is still valid.
+
+    POST /api/user/jwt/verify/
+    Body: { "token": "..." }
+    Returns: 200 OK if valid, 401 if expired/invalid
+    """
+
+
+class LogoutView(APIView):
+    """
+    Logout by blacklisting the refresh token.
+
+    POST /api/user/logout/
+    Header: Authorization: Bearer <access_token>
+    Body: { "refresh": "..." }
+
+    Blacklisting the refresh token means it can no longer be used to
+    obtain new access tokens, effectively ending the session.
+    """
+    authentication_classes = [JWTAuthentication, authentication.TokenAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        refresh_token = request.data.get('refresh')
+        if not refresh_token:
+            return Response(
+                {'detail': 'refresh token is required.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+        except Exception:
+            return Response(
+                {'detail': 'Token is invalid or already blacklisted.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response({'detail': 'Successfully logged out.'}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
Adds full JWT auth flow on top of the existing legacy token endpoint.

## New Endpoints

| Method | URL | Description |
|--------|-----|-------------|
| POST | `/api/user/jwt/login/` | Obtain access + refresh token pair |
| POST | `/api/user/jwt/refresh/` | Rotate refresh → new access + refresh |
| POST | `/api/user/jwt/verify/` | Verify an access token |
| POST | `/api/user/logout/` | Blacklist refresh token (end session) |

## Token Configuration
- **Access token**: 15 minutes, contains `name` + `email` claims (no extra `/me/` call needed on login)
- **Refresh token**: 7 days, rotated on every use (old token blacklisted automatically)
- **Login throttled**: 5 requests/minute via `LoginRateThrottle`

## Security
- Logout blacklists the refresh token via `rest_framework_simplejwt.token_blacklist`
- A blacklisted refresh token returns **401** on any further use
- Legacy `/api/user/token/` endpoint kept for backwards-compat

## Test plan
- [ ] `POST /api/user/jwt/login/` with valid creds → 200 + access + refresh
- [ ] `POST /api/user/jwt/login/` with bad creds → 401
- [ ] `POST /api/user/jwt/refresh/` with valid refresh → 200 + new access
- [ ] `POST /api/user/logout/` → 200, then refresh with old token → 401
- [ ] All existing tests still pass

Closes #5