### PR TITLE
feat: CI/CD improvements with coverage, bandit, and safety

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,15 +1,16 @@
 ---
-name: Checks
-# Workflow name visible in GitHub Actions UI
+name: CI
 
-on: [push]
-# Trigger: run workflow on every push
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
 
 jobs:
-  test-lint:
-    name: Test and Lint
+  test:
+    name: Test & Coverage
     runs-on: ubuntu-24.04
-    # Updated Ubuntu runner (old 20.04 removed)
 
     steps:
       - name: Login to Docker Hub
@@ -17,16 +18,82 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        # Logs into Docker Hub to avoid rate limits
 
       - name: Checkout
         uses: actions/checkout@v4
-        # Checks out repo so workflow can access code
 
-      - name: Test
-        run: docker compose run --rm app sh -c "python manage.py wait_for_db && python manage.py test"
-        # Runs Django unit tests inside Docker container
+      - name: Build image
+        run: docker compose build
 
-      - name: Lint
+      - name: Wait for DB and run migrations
+        run: docker compose run --rm app sh -c "python manage.py wait_for_db && python manage.py migrate --noinput"
+
+      - name: Run tests with coverage
+        run: |
+          docker compose run --rm app sh -c "
+            coverage run --source=. --omit='*/migrations/*,manage.py,app/settings.py' \
+              manage.py test &&
+            coverage report --fail-under=80 &&
+            coverage xml -o /app/coverage.xml
+          "
+
+      - name: Copy coverage report from container
+        if: always()
+        run: |
+          docker compose run --rm -v ${{ github.workspace }}:/workspace app sh -c \
+            "cp /app/coverage.xml /workspace/coverage.xml" || true
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    name: Lint (flake8)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run flake8
         run: docker compose run --rm app sh -c "flake8"
-        # Runs linter to check code style
+
+  security:
+    name: Security Scan (bandit + safety)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run bandit (SAST)
+        run: |
+          docker compose run --rm app sh -c "
+            bandit -r . \
+              --exclude ./migrations,./tests \
+              -ll \
+              --quiet
+          "
+
+      - name: Run safety (dependency audit)
+        run: |
+          docker compose run --rm app sh -c "safety check --full-report" || true
+        # 'true' because safety exits non-zero on any advisory;
+        # treat as informational until pinned versions are confirmed clean

--- a/app/.coveragerc
+++ b/app/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+source = .
+omit =
+    */migrations/*
+    manage.py
+    app/wsgi.py
+    app/asgi.py
+    */tests/*
+    */test_*.py
+
+[report]
+show_missing = True
+skip_covered = False
+fail_under = 80
+
+[html]
+directory = htmlcov

--- a/app/.flake8
+++ b/app/.flake8
@@ -1,6 +1,14 @@
 [flake8]
+max-line-length = 100
 exclude =
-   migrations, 
-   __pycache__,
-   manage.py,
-   settings.py
+    migrations,
+    __pycache__,
+    manage.py,
+    settings.py,
+    .git,
+    .venv,
+    htmlcov
+
+# E501: line too long (handled by max-line-length above)
+# W503: line break before binary operator (conflicts with black)
+extend-ignore = W503

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,13 @@
-# Dev packages (for optional dev environment)
+# Development & CI packages
+
+# Linting
 flake8>=3.9.2,<3.10
+
+# Test coverage
+coverage>=6.4,<7.0
+
+# Security scanning
+bandit>=1.7.4,<2.0
+
+# Dependency vulnerability check
+safety>=2.3.0,<3.0


### PR DESCRIPTION
## Summary
Splits the single CI job into three focused parallel jobs and adds security scanning + coverage reporting.

## CI Jobs

### 1. Test & Coverage
- Runs the full Django test suite with `coverage`
- Fails if coverage drops below **80%**
- Uploads `coverage.xml` to Codecov

### 2. Lint (flake8)
- `max-line-length = 100`
- Excludes migrations, `__pycache__`, `manage.py`, `settings.py`
- Ignores `W503` (conflicts with Black style)

### 3. Security Scan
- **bandit**: static analysis for common Python security issues (medium+ severity)
- **safety**: audits all installed packages against known CVE database

## Files Changed
| File | Change |
|------|--------|
| `.github/workflows/checks.yml` | Split into 3 parallel jobs |
| `requirements.dev.txt` | Added `coverage`, `bandit`, `safety` |
| `app/.coveragerc` | Coverage config with 80% threshold |
| `app/.flake8` | Updated max-line-length, ignore list |

## Test plan
- [ ] Push to any branch → all 3 CI jobs run in parallel
- [ ] Test with <80% coverage → build fails
- [ ] Check Codecov dashboard for coverage report

Closes #9